### PR TITLE
Replace deprecated function

### DIFF
--- a/transpose-frame.el
+++ b/transpose-frame.el
@@ -110,7 +110,7 @@
               (window-margins tree)
               (window-fringes tree)
               (window-dedicated-p tree)
-              (window-redisplay-end-trigger tree)
+              (jit-lock-register tree)
               tree
               (eq tree (frame-selected-window frame)))
       (let* ((vertical (car tree))
@@ -145,7 +145,7 @@
           (set-window-margins window (caar config) (cdr (pop config)))
           (apply 'set-window-fringes window (pop config))
           (set-window-dedicated-p window (pop config))
-          (set-window-redisplay-end-trigger window (pop config))
+          (jit-lock-register window (pop config))
           (let* ((orig-window (pop config))
                  (ol-func (lambda (ol)
                             (when (eq (overlay-get ol 'window) orig-window)


### PR DESCRIPTION
The redisplay-end-trigger functions were recently deprecated on emacs master: https://git.savannah.gnu.org/cgit/emacs.git/commit/etc/NEWS?id=5b29f8cd98c014b4b3e5844ef128ba97e65ea036

The NEWS section suggested that `jit-lock-register` should be used instead. I have tested this change locally, and it seems to work. However, I haven't really looked into the behavior of the new versus the deprecated function in detail, and I haven't tested the changed code very thoroughly.

I did use github to edit the file, but perhaps the minuteness of the change makes that acceptable. If not, I might be able to find time to redo the change using emacs and magit.